### PR TITLE
Options to title and wrap all figures

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@
  * @typedef {Record<string, Sources>} Options
  */
 
-import {visit} from 'unist-util-visit'
-import {isElement} from 'hast-util-is-element'
+import { visit } from 'unist-util-visit'
+import { isElement } from 'hast-util-is-element'
 import replaceExt from 'replace-ext'
 
 //const own = {}.hasOwnProperty
@@ -21,11 +21,16 @@ export default function rehypeFigureForImg(options) {
   return (tree) => {
     visit(tree, 'element', (node, index, parent) => {
       if (
-        !parent ||
-        typeof index !== 'number' ||
-        !isElement(node, 'img') ||
-        !node.properties ||
-        !node.properties.alt
+        (
+          !parent ||
+          typeof index !== 'number' ||
+          !isElement(node, 'img') ||
+          !node.properties
+        ) ||
+        (
+          !node.properties.title &&
+          !settings?.allImages
+        )
       ) {
         return
       }
@@ -40,7 +45,10 @@ export default function rehypeFigureForImg(options) {
         type: 'element',
         tagName: 'figure',
         properties: {},
-        children: nodes.concat(
+      }
+
+      if (node.properties.title) {
+        replacement.children = nodes.concat(
           [
             node,
             {
@@ -49,9 +57,16 @@ export default function rehypeFigureForImg(options) {
               properties: {},
               children: nodes.concat({
                 type: 'text',
-                value: node.properties.alt
+                value: node.properties.title
               })
             },
+          ]
+        )
+      }
+      else {
+        replacement.children = nodes.concat(
+          [
+            node,
           ]
         )
       }

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ import replaceExt from 'replace-ext'
  */
 export default function rehypeFigureForImg(options) {
   const settings = options || {}
+  const captionProperty = settings?.useTitle ? 'title' : 'alt'
 
   return (tree) => {
     visit(tree, 'element', (node, index, parent) => {
@@ -28,7 +29,7 @@ export default function rehypeFigureForImg(options) {
           !node.properties
         ) ||
         (
-          !node.properties.title &&
+          !node.properties[captionProperty] &&
           !settings?.allImages
         )
       ) {
@@ -47,7 +48,7 @@ export default function rehypeFigureForImg(options) {
         properties: {},
       }
 
-      if (node.properties.title) {
+      if (node.properties[captionProperty]) {
         replacement.children = nodes.concat(
           [
             node,
@@ -57,7 +58,7 @@ export default function rehypeFigureForImg(options) {
               properties: {},
               children: nodes.concat({
                 type: 'text',
-                value: node.properties.title
+                value: node.properties[captionProperty]
               })
             },
           ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rehype-figure-for-img",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rehype-figure-for-img",
-      "version": "0.0.1",
+      "version": "0.0.4",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^2.0.0",

--- a/readme.md
+++ b/readme.md
@@ -19,17 +19,41 @@ because it don't work ~~*at lest with me*~~.
 3. edit javascript object and add 
 ```js
 ...
-markdownOptions: {
-    render: [
-	    '@astrojs/markdown-remark',
-		    {
-            rehypePlugins: [
-                ...
-                // add this
-                ['rehype-figure-for-img'],
-            ]
-		    },
-	],
-	}
+markdown: {
+   rehypePlugins: [
+        ...
+        'rehype-figure-for-img'
+   ],
+},
 ...
 ```
+
+To add a caption to an image, add it to the title section of the markdown. This is separate from the alt text attribute.
+
+```md
+![This is the alt text for the image](/img/image.jpg "Here is a caption")
+```
+This markdown then becomes:
+```html
+<figure>
+    <img src="/img/image.jpg" alt="This is the alt text for the image" />
+    <figcaption>Here is a caption</figcaption>
+</figure>
+```
+
+## Plugin Options
+
+There are options you can add to the plugin. You can add options to the plugin as below:
+
+```js
+...
+markdown: {
+   rehypePlugins: [
+        ...
+        ['rehype-figure-for-img', { allImages: true }]
+   ],
+},
+...
+```
+
+- `allImages`: by default the plugin will only wrap figures around images with a caption, this adds the ability to add figures around all images (and add captions to any that have them)

--- a/readme.md
+++ b/readme.md
@@ -56,4 +56,5 @@ markdown: {
 ...
 ```
 
-- `allImages`: by default the plugin will only wrap figures around images with a caption, this adds the ability to add figures around all images (and add captions to any that have them)
+- `allImages`: (`false`) by default the plugin will only wrap figures around images with a caption, this adds the ability to add figures around all images (and add captions to any that have them)
+- `useTitle`: (`false`) by default the plugin will use the alt text as the caption, you can change this to use the title instead


### PR DESCRIPTION
Updated plugin to allow wrapping all images in figures, even if they don't have captions (option `allImages` added to plugin so remains backwards compatible)

Updated to allow using the title attribute (`useTitle`) rather than the alt attribute, so a text alternative can still be provided for accessibility purposes.

Updated readme to include info about options, and for the new markdown plugin syntax